### PR TITLE
[Fix] cname으로 서브 도메인 추가

### DIFF
--- a/.github/workflows/isitgone-develop.yml
+++ b/.github/workflows/isitgone-develop.yml
@@ -38,3 +38,4 @@ jobs:
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           publish_dir: build/web
+          cname: dev.isitgone.site


### PR DESCRIPTION
1. 설정에서 커스텀 도메인을 사용하면 gh-pages에 cname 파일이 생깁니다.
2. develop 브랜치에서 build 결과물을 gh-pages로 푸쉬할 때, 설정에서 건드렸던 cname 파일이 사라져서 커스텀 도메인 설정이 되지 않습니다.
3. 따라서 develop 브랜치에서 build할 때 cname 옵션을 주어, 커스텀 서브 도메인을 pages의 도메인으로 설정하도록 합니다.